### PR TITLE
Add server config switch to disable RPP API

### DIFF
--- a/server/apps/chaosarchives/src/api/rpp/rpp.module.ts
+++ b/server/apps/chaosarchives/src/api/rpp/rpp.module.ts
@@ -4,13 +4,14 @@ import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { RppController } from "./rpp.controller";
 import { RppService } from "./rpp.service";
+import { serverConfiguration } from "@app/configuration";
 
-@Module({
+@Module(serverConfiguration.apis.rpp ? {
 	imports: [
 		TypeOrmModule.forFeature([ Character ]),
     AuthModule,
 	],
 	controllers: [ RppController ],
 	providers: [ RppService ],
-})
+} : {})
 export class RppModule {}

--- a/server/apps/chaosarchives/src/main.ts
+++ b/server/apps/chaosarchives/src/main.ts
@@ -10,20 +10,22 @@ async function bootstrap() {
   app.setGlobalPrefix('api');
   app.useGlobalPipes(transformAndValidate);
 
-  // Add Swagger for RPP API
-  const swaggerConfig = new DocumentBuilder()
-    .setTitle('Chaos Archives RPP API')
-    .setVersion('1.0')
-    .addBearerAuth({
-      type: 'apiKey',
-      description: 'Access token obtained by /login'
-    })
-    .build();
+  if (serverConfiguration.apis.rpp) {
+    // Add Swagger for RPP API
+    const swaggerConfig = new DocumentBuilder()
+      .setTitle('Chaos Archives RPP API')
+      .setVersion('1.0')
+      .addBearerAuth({
+        type: 'apiKey',
+        description: 'Access token obtained by /login'
+      })
+      .build();
 
-  const swaggerDoc = SwaggerModule.createDocument(app, swaggerConfig, {
-    include: [ RppModule ],
-  });
-  SwaggerModule.setup('api/rpp/swagger', app, swaggerDoc);
+    const swaggerDoc = SwaggerModule.createDocument(app, swaggerConfig, {
+      include: [ RppModule ],
+    });
+    SwaggerModule.setup('api/rpp/swagger', app, swaggerDoc);
+  }
 
   await app.listen(serverConfiguration.port);
 }

--- a/server/config/default.yml
+++ b/server/config/default.yml
@@ -5,6 +5,8 @@ server:
   maxUploadSpacePerUserMiB: 200
   stewardWebhookPort: 8112
   stewardWebhookUrl: 'http://steward:8112'
+  apis:
+    rpp: true
 
 db:
   type: 'mariadb'

--- a/server/libs/configuration/src/interfaces/server-config.interface.ts
+++ b/server/libs/configuration/src/interfaces/server-config.interface.ts
@@ -6,4 +6,7 @@ export interface ServerConfigInterface {
 	maxUploadSpacePerUserMiB: number,
 	stewardWebhookPort: number,
 	stewardWebhookUrl: string,
+	apis: {
+		rpp: boolean;
+	}
 }


### PR DESCRIPTION
Hello from the Chaos Archives developer :)

First of all, I'm deeply honored to see my hobby project forked, actively developed, deployed and used!

Currently your deployment has the RPP API enabled, including its online Swagger documentation. The RPP API was added as the backend side of the [Roleplay Profiles](https://github.com/Maia-Everett/dalamud-roleplay-profiles) Dalamud plugin. I'm not sure you want that — unless, of course, you would rather the plugin query your site, rather than Chaos Archives, for German profiles on Light, in which case I could code that into the plugin.

https://elpisgarten.de/api/rpp/swagger/

I've just added a config switch to Chaos Archives main that allows disabling it. This PR cherry-picks that commit, so you can disable the RPP API in your `production.yml` overrides if you so desire.

If you need any help from me, including easing the task of keeping our repositories in sync, don't hesitate to ask!